### PR TITLE
fix - use redirect from CLIENT_URL

### DIFF
--- a/routes/public/auth.routes.js
+++ b/routes/public/auth.routes.js
@@ -21,7 +21,7 @@ router.get(
 
 router.get('/auth/spotify/callback',
   passport.authenticate('spotify'), (req, res) => {
-    res.redirect('http://localhost:3000/discovery');
+    res.redirect(`${process.env.CLIENT_URL}/discovery`);
 });
 
 router.get('/logout', (req, res) => {


### PR DESCRIPTION
Fixes wrong redirect url on heroku